### PR TITLE
Add section for hoofdmentoren

### DIFF
--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -2,6 +2,7 @@ import React, { Component } from "react";
 import ContactPerson from './ContactPerson';
 import Date from './Date';
 import data from './data.json';
+import Mentor from './Mentor';
 import Question from './Question';
 import Text from './Text';
 import Association from "./Association";
@@ -35,6 +36,13 @@ class Home extends Component {
               <p className="anchor" id="verenigingen"></p>
               <p className="ui center aligned large header">Verenigingen</p>
               {getAssociation(data.Associations)}
+            </div>
+          </div>
+          <div className="ui fluid card">
+            <div className="card content">
+              <p className="anchor" id="hoofdmentoren"></p>
+              <p className="ui center aligned large header">Hoofdmentoren</p>
+              {getMentors(data.Mentors)}
             </div>
           </div>
           <div className="ui fluid card">
@@ -103,6 +111,17 @@ const getAssociation = associations =>{
       {
         associations.map((association, index)=>(
           <Association association={association} key={index}/>
+        ))
+      }
+    </div>
+  )
+}
+const getMentors = mentors=>{
+  return (
+    <div className="ui centered four doubling cards">
+      {
+        mentors.map((mentor, index)=>(
+          <Mentor mentor={mentor} key={index}/>
         ))
       }
     </div>

--- a/src/components/Mentor.jsx
+++ b/src/components/Mentor.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+const Mentor = ({ mentor }) => (
+    <div className="ui segment">
+        <h2 className="ui left aligned large header">{mentor.name}</h2>
+        <img className="ui right floated medium spaced image mentor" src={require('../assets/logos/' + mentor.photo)} alt={mentor.name}/>
+	<h3>{mentor.study}</h3>
+        <p>{mentor.text}</p>
+	<footer>{mentor.contactInfo}</footer>
+    </div>
+
+);
+export default Mentor;

--- a/src/components/data.json
+++ b/src/components/data.json
@@ -74,6 +74,15 @@
             "link": "https://www.a-eskwadraat.nl/"
         }
     ],
+    "Mentors": [
+	    {
+		    "name": "Lorem",
+		    "photo": "sticky.png",
+		    "study": "Lorem ipsum",
+		    "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus placerat gravida ligula, nec vulputate libero. Vivamus dictum felis velit, in fringilla nisi aliquet quis.",
+		    "contactInfo": "Lorem ipsum"
+	    }
+    ],
     "FAQ": [
         {
             "question": "Wanneer is de introductie?",


### PR DESCRIPTION
Simple hoofdmentoren section based on Association section

Serves its purpose, perhaps style in column-wise instead of row-wise to have portraits of mentors side by side.

Fixes #75